### PR TITLE
Allow specifying selenium node dns

### DIFF
--- a/src/main/groovy/ru/qatools/selenoud/AbstractCloud.groovy
+++ b/src/main/groovy/ru/qatools/selenoud/AbstractCloud.groovy
@@ -56,13 +56,14 @@ abstract class AbstractCloud implements Cloud {
             final caps = getCaps(body)
             final browser = caps.browserName as String
             final version = (caps.version ?: null) as String
+            final options = (caps.selenoud ?: [:]) as Map
 
             request.add(BrowserContext, new BrowserContext(name: containerName, browser: browser, version: version))
 
-            LOG.info('[{}:{}] [SESSION_ATTEMPTED] [{}]', browser, version, containerName)
+            LOG.info('[{}:{}] [SESSION_ATTEMPTED] [{}] [{}]', browser, version, containerName, options)
 
             try {
-                final container = launchContainer(browser, version, containerName)
+                final container = launchContainer(browser, version, containerName, options)
                 LOG.info('[{}:{}] [CONTAINER_CREATED] [{}] [{}]', browser, version, containerName, container.id)
                 createSession(request, response, client, body, waitForNode(container).orElseThrow({
                     new RuntimeException("Failed to launch container and create session for ${containerName}!")
@@ -150,7 +151,7 @@ abstract class AbstractCloud implements Cloud {
         inputStreamToResponse(logCollector.get(sessionId.split(':')[0]), response)
     }
 
-    protected abstract Container launchContainer(String browserName, String browserVersion, String name)
+    protected abstract Container launchContainer(String browserName, String browserVersion, String name, Map options)
 
     protected abstract void removeContainer(String containerName)
 


### PR DESCRIPTION
This allows developers to use a shared selenium grid. This option can be
specified in the selenium desiredCapabilities section as:

``` ruby
Selenium::WebDriver::Remote::Capabilities.chrome(
  'selenoud': {
    'dns': '10.200.0.42'
  }
)_
```

I initially tried to add this param to URL but that didn't work out well. The capabilities might not be the best place to put this but that's how I got it to work.

Our use case for this:
We have one big selenium grid using selenoud. Every developer has a local machine which has dns set up (e.g. my-app.local.dev). This now allows every developer to use the same selenium grid by just pointing the dns to their own machine.

Note: first time writing groovy.
