### PR TITLE
Add content type to the session created response

### DIFF
--- a/src/main/groovy/ru/qatools/selenoud/AbstractCloud.groovy
+++ b/src/main/groovy/ru/qatools/selenoud/AbstractCloud.groovy
@@ -205,7 +205,7 @@ abstract class AbstractCloud implements Cloud {
                     LOG.info('[{}:{}] [SESSION_CREATED] [{}] [{}]', container.browser, container.version,
                             container.name, sessionId)
                 }
-                response.send(toJson(hubResponse))
+                response.send('application/json', toJson(hubResponse))
             }
         } catch (Exception e) {
             LOG.warn('[{}:{}] [SESSION_FAILED] [{}] [{}]', container.browser, container.version, container.name, e.message, e)


### PR DESCRIPTION
ruby-selenium driver fails if the response is not with correct content type. See https://github.com/SeleniumHQ/selenium/blob/a870613cc8228f93913684893e38e423acab3b06/rb/lib/selenium/webdriver/remote/http/common.rb#L79

Previously it returned the response with content type "text/plain". See https://ratpack.io/manual/current/api/ratpack/http/Response.html#send-java.lang.String-

Now providing a content type using https://ratpack.io/manual/current/api/ratpack/http/Response.html#send-java.lang.CharSequence-java.lang.String- instead
